### PR TITLE
Adjust patch automerge for packages

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,7 +21,7 @@
   "rangeStrategy": "bump",
   "timezone": "America/Los_Angeles",
   "patch": {
-    "automerge": true
+    "automergeType": "pr"
   },
   "rebaseWhen": "behind-base-branch"
 }

--- a/src/projen/renovate.js
+++ b/src/projen/renovate.js
@@ -42,7 +42,7 @@ const renovateAppOptions = {
 const renovatePackageOptions = {
   overrideConfig: {
     patch: {
-      automerge: true,
+      automergeType: 'pr',
     },
     rebaseWhen: 'behind-base-branch',
   },


### PR DESCRIPTION
With auto-merge set to true at the root for comments, this needs to be set back to PR for patches.